### PR TITLE
Update obs/deployments to use the loki prefix

### DIFF
--- a/environments/dev/main.jsonnet
+++ b/environments/dev/main.jsonnet
@@ -44,7 +44,7 @@ local up =
           cpu: '500m',
         },
       },
-      readEndpoint:: '%s://%s:%d/api/logs/v1/%s/api/v1/query' % [
+      readEndpoint:: '%s://%s:%d/api/logs/v1/%s/loki/api/v1/query' % [
         defaultConfig.obs.scheme,
         defaultConfig.obs.hostname,
         defaultConfig.obs.port,

--- a/environments/dev/manifests/observatorium-promtail-configmap.yaml
+++ b/environments/dev/manifests/observatorium-promtail-configmap.yaml
@@ -4,8 +4,8 @@ data:
     "clients":
     - "bearer_token_file": "/var/shared/token"
       "external_labels":
-        "observatorium": "test"
-      "url": "http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/api/v1/push"
+        "observatorium": "e2e-test"
+      "url": "http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/loki/api/v1/push"
     "scrape_configs":
     - "job_name": "kubernetes-pods-name"
       "kubernetes_sd_configs":

--- a/environments/dev/manifests/observatorium-up-logs-configmap.yaml
+++ b/environments/dev/manifests/observatorium-up-logs-configmap.yaml
@@ -3,7 +3,7 @@ data:
   queries.yaml: |-
     "queries":
     - "name": "obervatorium-test-tenant"
-      "query": "{observatorium=\"test\"}"
+      "query": "{observatorium=\"e2e-test\"}"
 kind: ConfigMap
 metadata:
   labels:

--- a/environments/dev/manifests/observatorium-up-logs.yaml
+++ b/environments/dev/manifests/observatorium-up-logs.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - args:
         - --endpoint-type=logs
-        - --endpoint-read=http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/api/v1/query
+        - --endpoint-read=http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/loki/api/v1/query
         - --queries-file=/var/up/queries.yaml
         - --period=1s
         - --duration=2m

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "environments/dev"
         }
       },
-      "version": "3ef8c277206bb0f28a6a7a1d23db2bf980662977",
-      "sum": "GG/EK9Y7utsiA8LXxAVa2Z+UvRPe7ulT8dLDNDB+c/k=",
+      "version": "df31fe91fc67e566148301a347890c8265139de6",
+      "sum": "EnsugFl6J9l+PXAgBK+saj3d3PdpC/m7Ui8MTD9qcls=",
       "name": "observatorium"
     }
   ],

--- a/promtail/promtail.libsonnet
+++ b/promtail/promtail.libsonnet
@@ -81,7 +81,7 @@ config + scrape_config {
 
   promtail_config+:: {
     local client_config(client) = client {
-      url: '%(scheme)s://%(hostname)s/api/logs/v1/%(tenant_id)s/api/v1/push' % client,
+      url: '%(scheme)s://%(hostname)s/api/logs/v1/%(tenant_id)s/loki/api/v1/push' % client,
       bearer_token_file: '/var/shared/token',
     },
 

--- a/vendor/github.com/observatorium/deployments/environments/dev/main.jsonnet
+++ b/vendor/github.com/observatorium/deployments/environments/dev/main.jsonnet
@@ -91,6 +91,18 @@ local obs = (import '../base/observatorium.jsonnet') + {
               ],
               usernameClaim: 'email',
             },
+            rateLimits: [
+              {
+                endpoint: '/api/metrics/v1/.+/api/v1/receive',
+                limit: 1000,
+                window: '1s',
+              },
+              {
+                endpoint: '/api/logs/v1/.*',
+                limit: 1000,
+                window: '1s',
+              },
+            ],
           },
         ],
       },

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-configmap.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-configmap.yaml
@@ -25,6 +25,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-09-08-v0.1.1-142-g61a908f
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-09-08-v0.1.1-142-g61a908f
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 spec:
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: observatorium-api
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-09-08-v0.1.1-142-g61a908f
+        app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
     spec:
       containers:
       - args:
@@ -42,7 +42,8 @@ spec:
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
-        image: quay.io/observatorium/observatorium:master-2020-09-08-v0.1.1-142-g61a908f
+        - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
+        image: quay.io/observatorium/observatorium:master-2020-11-02-v0.1.1-192-ge324057
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-secret.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-09-08-v0.1.1-142-g61a908f
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 stringData:
@@ -19,3 +19,10 @@ stringData:
         "clientSecret": "ZXhhbXBsZS1hcHAtc2VjcmV0"
         "issuerURL": "http://dex.dex.svc.cluster.local:5556/dex"
         "usernameClaim": "email"
+      "rateLimits":
+      - "endpoint": "/api/metrics/v1/.+/api/v1/receive"
+        "limit": 1000
+        "window": "1s"
+      - "endpoint": "/api/logs/v1/.*"
+        "limit": 1000
+        "window": "1s"

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-09-08-v0.1.1-142-g61a908f
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-serviceAccount.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/api-serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-09-08-v0.1.1-142-g61a908f
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: rate-limiter
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: gubernator
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 1.0.0-rc.1
+  name: observatorium-xyz-gubernator
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rate-limiter
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: gubernator
+      app.kubernetes.io/part-of: observatorium
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: 1.0.0-rc.1
+    spec:
+      containers:
+      - env:
+        - name: GUBER_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GUBER_K8S_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: GUBER_HTTP_ADDRESS
+          value: 0.0.0.0:8080
+        - name: GUBER_GRPC_ADDRESS
+          value: 0.0.0.0:8081
+        - name: GUBER_K8S_POD_PORT
+          value: "8081"
+        - name: GUBER_K8S_ENDPOINTS_SELECTOR
+          value: app.kubernetes.io/name=gubernator
+        image: thrawn01/gubernator:1.0.0-rc.1
+        name: gubernator
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8081
+          name: grpc
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /v1/HealthCheck
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 1
+        resources:
+          limits: {}
+          requests: {}
+      restartPolicy: Always
+      serviceAccount: observatorium-xyz-gubernator

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-role.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rate-limiter
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: gubernator
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 1.0.0-rc.1
+  name: observatorium-xyz-gubernator
+  namespace: observatorium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - list
+  - watch
+  - get

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-roleBinding.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-roleBinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rate-limiter
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: gubernator
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 1.0.0-rc.1
+  name: observatorium-xyz-gubernator
+  namespace: observatorium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: observatorium-xyz-gubernator
+subjects:
+- kind: ServiceAccount
+  name: observatorium-xyz-gubernator
+  namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: rate-limiter
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: gubernator
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 1.0.0-rc.1
+  name: observatorium-xyz-gubernator
+  namespace: observatorium
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  - name: grpc
+    port: 8081
+    targetPort: 8081
+  selector:
+    app.kubernetes.io/component: rate-limiter
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: gubernator
+    app.kubernetes.io/part-of: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-serviceAccount.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/gubernator-serviceAccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rate-limiter
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: gubernator
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 1.0.0-rc.1
+  name: observatorium-xyz-gubernator
+  namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-compactor-grpc-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-compactor-grpc-service.yaml
@@ -2,21 +2,21 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: table-manager
+    app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
-  name: observatorium-xyz-loki-table-manager-grpc
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:
   clusterIP: None
   ports:
-  - name: grcp
+  - name: grpc
     port: 9095
     targetPort: 9095
   selector:
-    app.kubernetes.io/component: table-manager
+    app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-compactor-http-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-compactor-http-service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
     app.kubernetes.io/version: 2.0.0
-  name: observatorium-xyz-loki-query-frontend-http
+  name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:
   ports:
@@ -15,7 +15,7 @@ spec:
     port: 3100
     targetPort: 3100
   selector:
-    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-compactor-statefulset.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-compactor-statefulset.yaml
@@ -1,33 +1,34 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
-    app.kubernetes.io/component: table-manager
+    app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
-  name: observatorium-xyz-loki-table-manager
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: table-manager
+      app.kubernetes.io/component: compactor
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
+  serviceName: observatorium-xyz-loki-compactor-grpc
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: table-manager
+        app.kubernetes.io/component: compactor
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
     spec:
       containers:
       - args:
-        - -target=table-manager
+        - -target=compactor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
@@ -39,8 +40,8 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
-        name: observatorium-xyz-loki-table-manager
+        image: docker.io/grafana/loki:2.0.0
+        name: observatorium-xyz-loki-compactor
         ports:
         - containerPort: 3100
           name: metrics
@@ -55,10 +56,10 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 200Mi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
         volumeMounts:
         - mountPath: /etc/loki/config/
@@ -71,5 +72,16 @@ spec:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-      - emptyDir: {}
-        name: storage
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+      name: storage
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Mi

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-config-map.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-config-map.yaml
@@ -4,6 +4,10 @@ data:
     "auth_enabled": true
     "chunk_store_config":
       "max_look_back_period": "0s"
+    "compactor":
+      "compaction_interval": "2h"
+      "shared_store": "s3"
+      "working_directory": "/data/loki/compactor"
     "distributor":
       "ring":
         "kvstore":
@@ -43,6 +47,7 @@ data:
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
+      "max_cache_freshness_per_query": "10m"
       "max_global_streams_per_user": 10000
       "max_query_length": "12000h"
       "max_query_parallelism": 32
@@ -72,7 +77,7 @@ data:
       "split_queries_by_interval": "30m"
     "schema_config":
       "configs":
-      - "from": "2018-04-15"
+      - "from": "2020-10-01"
         "index":
           "period": "24h"
           "prefix": "loki_index_"
@@ -91,21 +96,9 @@ data:
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "resync_interval": "5s"
+        "cache_ttl": "24h"
+        "resync_interval": "5m"
         "shared_store": "s3"
-    "table_manager":
-      "chunk_tables_provisioning":
-        "inactive_read_throughput": 0
-        "inactive_write_throughput": 0
-        "provisioned_read_throughput": 0
-        "provisioned_write_throughput": 0
-      "index_tables_provisioning":
-        "inactive_read_throughput": 0
-        "inactive_write_throughput": 0
-        "provisioned_read_throughput": 0
-        "provisioned_write_throughput": 0
-      "retention_deletes_enabled": false
-      "retention_period": "0s"
   overrides.yaml: '{}'
 kind: ConfigMap
 metadata:
@@ -113,6 +106,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-distributor-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-distributor-grpc-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-distributor-grpc-service.yaml
@@ -6,13 +6,13 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:
   clusterIP: None
   ports:
-  - name: grcp
+  - name: grpc
     port: 9095
     targetPort: 9095
   selector:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-distributor-http-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-gossip-ring.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-ingester-grpc-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-ingester-grpc-service.yaml
@@ -6,13 +6,13 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:
   clusterIP: None
   ports:
-  - name: grcp
+  - name: grpc
     port: 9095
     targetPort: 9095
   selector:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-ingester-http-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-ingester-statefulset.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-querier-grpc-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-querier-grpc-service.yaml
@@ -6,13 +6,13 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:
   clusterIP: None
   ports:
-  - name: grcp
+  - name: grpc
     port: 9095
     targetPort: 9095
   selector:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-querier-http-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-querier-statefulset.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,13 +6,13 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:
   clusterIP: None
   ports:
-  - name: grcp
+  - name: grpc
     port: 9095
     targetPort: 9095
   selector:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-compact-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-compact-service.yaml
@@ -6,14 +6,14 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-compact
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
   ports:
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: observatorium-xyz

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-compact-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-compact
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-compact
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-08-12-70f89d83
+        app.kubernetes.io/version: v0.16.0
     spec:
       containers:
       - args:
@@ -39,15 +39,15 @@ spec:
         - --retention.resolution-5m=1s
         - --retention.resolution-1h=1s
         - --delete-delay=48h
-        - --deduplication.replica-label=replica
         - --downsampling.disable
+        - --deduplication.replica-label=replica
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+        image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -66,13 +66,25 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/compact
           name: data
           readOnly: false
       terminationGracePeriodSeconds: 120
-      volumes:
-      - emptyDir: {}
-        name: data
-  volumeClaimTemplates: null
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-query
   namespace: observatorium
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-08-12-70f89d83
+        app.kubernetes.io/version: v0.16.0
     spec:
       affinity:
         podAntiAffinity:
@@ -43,9 +43,9 @@ spec:
       containers:
       - args:
         - query
-        - --log.level=info
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090
+        - --log.level=info
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --query.replica-label=replica
@@ -53,7 +53,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
-        image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+        image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -74,5 +74,6 @@ spec:
             port: 9090
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 120

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-frontend-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query-frontend
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-query-frontend
   namespace: observatorium
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-query-frontend
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-08-12-70f89d83
+        app.kubernetes.io/version: v0.16.0
     spec:
       affinity:
         podAntiAffinity:
@@ -48,14 +48,14 @@ spec:
         - --query-frontend.downstream-url=http://observatorium-xyz-thanos-query.observatorium.svc.cluster.local.:9090
         - --query-range.split-interval=24h
         - --query-range.max-retries-per-request=0
-        - --query-frontend.log_queries_longer_than=5s
+        - --query-frontend.log-queries-longer-than=5s
         - |-
           --query-range.response-cache-config="config":
             "max_size": "0"
             "max_size_items": 2048
             "validity": "6h"
           "type": "in-memory"
-        image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+        image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -74,5 +74,6 @@ spec:
             port: 9090
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 120

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-frontend-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-frontend-service.yaml
@@ -6,14 +6,14 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query-frontend
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-query-frontend
   namespace: observatorium
 spec:
   ports:
   - name: http
     port: 9090
-    targetPort: http
+    targetPort: 9090
   selector:
     app.kubernetes.io/component: query-cache
     app.kubernetes.io/instance: observatorium-xyz

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-frontend-serviceMonitor.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-frontend-serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query-frontend
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-query-frontend
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-query-service.yaml
@@ -6,17 +6,17 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-query
   namespace: observatorium
 spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
   - name: http
     port: 9090
-    targetPort: http
+    targetPort: 9090
   selector:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: observatorium-xyz

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-controller-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-controller-deployment.yaml
@@ -42,4 +42,5 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        resources: {}
       serviceAccount: observatorium-xyz-thanos-receive-controller

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-default-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-default-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
     controller.receive.thanos.io/hashring: default
   name: observatorium-xyz-thanos-receive-default
   namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-default-statefulSet.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-default-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
     controller.receive.thanos.io: thanos-receive-controller
     controller.receive.thanos.io/hashring: default
   name: observatorium-xyz-thanos-receive-default
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-receive
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-08-12-70f89d83
+        app.kubernetes.io/version: v0.16.0
         controller.receive.thanos.io/hashring: default
     spec:
       affinity:
@@ -76,8 +76,8 @@ spec:
         - --tsdb.path=/var/thanos/receive
         - --label=replica="$(NAME)"
         - --label=receive="true"
-        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --tsdb.retention=4d
+        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         env:
         - name: NAME
@@ -95,7 +95,7 @@ spec:
               name: thanos-objectstorage
         - name: DEBUG
           value: "1"
-        image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+        image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -118,6 +118,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive
@@ -127,9 +128,21 @@ spec:
           name: hashring-config
       terminationGracePeriodSeconds: 900
       volumes:
-      - emptyDir: {}
-        name: data
       - configMap:
           name: observatorium-xyz-thanos-receive-controller-tenants-generated
         name: hashring-config
-  volumeClaimTemplates: null
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+        controller.receive.thanos.io/hashring: default
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-receive-service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/part-of: observatorium
   name: observatorium-xyz-thanos-receive
   namespace: observatorium
 spec:

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-rule-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-rule-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-rule
   namespace: observatorium
 spec:
@@ -14,10 +14,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: observatorium-xyz

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-rule-statefulSet.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-rule-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
   name: observatorium-xyz-thanos-rule
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-rule
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-08-12-70f89d83
+        app.kubernetes.io/version: v0.16.0
     spec:
       containers:
       - args:
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+        image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 24
           httpGet:
@@ -70,12 +70,24 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/rule
           name: data
           readOnly: false
-      volumes:
-      - emptyDir: {}
-        name: data
-  volumeClaimTemplates: null
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-store-shard0-service.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-store-shard0-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-store
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
     store.observatorium.io/shard: shard-0
   name: observatorium-xyz-thanos-store-shard-0
   namespace: observatorium

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/thanos-store-shard0-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: thanos-store
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-08-12-70f89d83
+    app.kubernetes.io/version: v0.16.0
     store.observatorium.io/shard: shard-0
   name: observatorium-xyz-thanos-store-shard-0
   namespace: observatorium
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: thanos-store
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-08-12-70f89d83
+        app.kubernetes.io/version: v0.16.0
         store.observatorium.io/shard: shard-0
     spec:
       affinity:
@@ -56,6 +56,7 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
+        - --ignore-deletion-marks-delay=24h
         - --experimental.enable-index-cache-postings-compression
         - |-
           --index-cache.config="config":
@@ -92,7 +93,6 @@ spec:
           "metafile_exists_ttl": "2h"
           "metafile_max_size": "1MiB"
           "type": "memcached"
-        - --ignore-deletion-marks-delay=24h
         - |
           --selector.relabel-config=
             - action: hashmod
@@ -108,7 +108,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+        image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -129,13 +129,26 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
       terminationGracePeriodSeconds: 120
-      volumes:
-      - emptyDir: {}
-        name: data
-  volumeClaimTemplates: null
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        store.observatorium.io/shard: shard-0
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/vendor/github.com/observatorium/deployments/environments/dev/manifests/up-deployment.yaml
+++ b/vendor/github.com/observatorium/deployments/environments/dev/manifests/up-deployment.yaml
@@ -1,6 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/component: blackbox-prober
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: observatorium-up
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: master-2020-06-03-8a20b4e
   name: observatorium-xyz-observatorium-up
   namespace: observatorium
 spec:


### PR DESCRIPTION
This PR updates the `observatorium/deployments` dep to use the obs-api with the upstream prefix `/loki` introduced by: observatorium/deployments#357